### PR TITLE
Fix Malformed Hyperlink

### DIFF
--- a/templates/html.twig
+++ b/templates/html.twig
@@ -77,7 +77,7 @@
       FAST MUSIC solo band from New Zealand, visit <a href="http://disasteradio.org">disasteradio.org</a>
       instead.</p>
     <p><strong>disaster.radio</strong> is a collaborative project between <a href="https://sudoroom.org/wiki/Mesh">Sudo
-      Mesh</a> and <a href="https://www.scuttlebutt.nz">Secure Scuttlebutt</a>, with additional support from the <a href="https://isoc.org">Internet Society</a> and <a href="https://www.iftf.org/">Institute For the Future</a.</p>
+      Mesh</a> and <a href="https://www.scuttlebutt.nz">Secure Scuttlebutt</a>, with additional support from the <a href="https://isoc.org">Internet Society</a> and <a href="https://www.iftf.org/">Institute For the Future</a>.</p>
     <p>Except where otherwise noted, content on this site is licensed under a <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License v3</a> license.<br>
 <a href="https://github.com/sudomesh/disaster-radio-website">Fork this site on Github</a></p>
   </div>


### PR DESCRIPTION
Typo caused hyperlink to not close properly. Fixed closing `</a>`.